### PR TITLE
Add prefitted error msg & Fixed R 4.5.2 compatibility** in `.calc_dens()` function

### DIFF
--- a/R/calc_dens.R
+++ b/R/calc_dens.R
@@ -33,6 +33,17 @@
     if ("G" %in% names(GMM_params)){
         stop("G cannot be specified in `GMM_params`. This is specified by `num_components` instead.")
     }
+        # `mclust::densityMclust()` expects column names when invoked through
+        # `do.call()` (required for R >= 4.5, otherwise it errors while assigning
+        # dimnames).  Normalise the matrices once up front to avoid repeatedly
+        # copying large objects inside the parallel loop.
+        df_list <- lapply(df_list, function(mat){
+            if (is.null(colnames(mat))) {
+                colnames(mat) <- paste0("V", seq_len(ncol(mat)))
+            }
+            mat
+        })
+        
         mod_list <- BiocParallel::bplapply(df_list, function(z){
             GMM_params$data <- z
             GMM_params$G <- get_gmm_num_components_vec(nrow(z),num_components)

--- a/R/gloscope.R
+++ b/R/gloscope.R
@@ -108,8 +108,41 @@ gloscope <- function(embedding_matrix, cell_sample_ids,
         k = k, num_components = num_components,
         GMM_params = GMM_params, BPPARAM = BPPARAM)
     } else {
+        # Validate that prefit_density contains densityMclust objects
+        for(i in seq_along(prefit_density)){
+            obj <- prefit_density[[i]]
+            obj_name <- names(prefit_density)[i]
+            if(is.null(obj_name)) obj_name <- paste0("[[", i, "]]")
+           
+            # Check if it's a densityMclust object
+            if(!inherits(obj, "densityMclust")){
+                # Provide specific guidance if it's a Mclust object
+                if(inherits(obj, "Mclust")){
+                    stop(
+                        sprintf(
+                            "prefit_density%s is a 'Mclust' object, but 'densityMclust' is required.\n",
+                            obj_name
+                        ),
+                        "  Use mclust::densityMclust() instead of mclust::Mclust().\n",
+                        "  Example: densityMclust(data, G = 12, modelNames = 'VVE', plot = FALSE)\n",
+                        "  See ?gloscope for more details."
+                    )
+                } else {
+                    stop(
+                        sprintf(
+                            "prefit_density%s must be a 'densityMclust' object.\n",
+                            obj_name
+                        ),
+                        "  Found object of class: ", class(obj)[1], "\n",
+                        "  Use mclust::densityMclust() to create the correct object type.\n",
+                        "  Example: densityMclust(data, G = 12, modelNames = 'VVE', plot = FALSE)"
+                    )
+                }
+            }
+        }
         mod_list <- prefit_density
     }
+
 
     sample_pairs <- utils::combn(unique_sample_ids, 2)
     # Convert patient pairs to a list for BiocParallel::bplapply

--- a/tests/testthat/test-prefit-density.R
+++ b/tests/testthat/test-prefit-density.R
@@ -1,0 +1,112 @@
+library(testthat)
+library(mclust)
+
+test_that("gloscope validates prefit_density object types", {
+    # Use the small test data from setup_data.R
+    sample_ids <- subsample_metadata$sample_id
+    
+    # Create sample embedding list for testing (needed for creating mclust objects)
+    embeddings_list <- lapply(unique(sample_ids), function(x) {
+        subsample_data_subset[(sample_ids == x), ]
+    })
+    names(embeddings_list) <- unique(sample_ids)
+    
+    # Test 1: Error when prefit_density contains Mclust object (wrong type)
+    mclust_obj <- mclust::Mclust(
+        embeddings_list[[1]], 
+        G = 5, 
+        modelNames = "VVE",
+        verbose = FALSE
+    )
+    prefit_wrong_mclust <- list(mclust_obj)
+    names(prefit_wrong_mclust) <- names(embeddings_list)[1]
+    
+    expect_error(
+        gloscope(
+            subsample_data_subset,
+            sample_ids,
+            dens = "GMM",
+            prefit_density = prefit_wrong_mclust
+        ),
+        regexp = "is a 'Mclust' object, but 'densityMclust' is required"
+    )
+    
+    # Test 2: Error message suggests correct function (densityMclust)
+    expect_error(
+        gloscope(
+            subsample_data_subset,
+            sample_ids,
+            dens = "GMM",
+            prefit_density = prefit_wrong_mclust
+        ),
+        regexp = "mclust::densityMclust\\(\\)"
+    )
+    
+    # Test 3: Error when prefit_density contains completely wrong object type
+    prefit_wrong_type <- list(matrix(1:10, nrow = 5))
+    names(prefit_wrong_type) <- names(embeddings_list)[1]
+    
+    expect_error(
+        gloscope(
+            subsample_data_subset,
+            sample_ids,
+            dens = "GMM",
+            prefit_density = prefit_wrong_type
+        ),
+        regexp = "must be a 'densityMclust' object"
+    )
+    
+    # Test 4: Error message includes object name for named list
+    expect_error(
+        gloscope(
+            subsample_data_subset,
+            sample_ids,
+            dens = "GMM",
+            prefit_density = prefit_wrong_mclust
+        ),
+        regexp = names(embeddings_list)[1]
+    )
+    
+    # Test 5: Error message includes index [[1]] for unnamed list
+    prefit_unnamed <- list(mclust_obj)
+    expect_error(
+        gloscope(
+            subsample_data_subset,
+            sample_ids,
+            dens = "GMM",
+            prefit_density = prefit_unnamed
+        ),
+        regexp = "\\[\\[1\\]\\]"
+    )
+    
+    # Test 6: Success with correct densityMclust objects
+    # Create correct densityMclust objects for all samples
+    prefit_correct <- lapply(names(embeddings_list), function(sample_name) {
+        mclust::densityMclust(
+            embeddings_list[[sample_name]],
+            G = 5,
+            modelNames = "VVE",
+            plot = FALSE,
+            verbose = FALSE
+        )
+    })
+    names(prefit_correct) <- names(embeddings_list)
+    
+    expect_silent(
+        result <- gloscope(
+            subsample_data_subset,
+            sample_ids,
+            dens = "GMM",
+            prefit_density = prefit_correct,
+            BPPARAM = BiocParallel::SerialParam(RNGseed = 2)
+        )
+    )
+    
+    # Verify result is a valid divergence matrix
+    expect_equal(dim(result), c(length(unique(sample_ids)), length(unique(sample_ids))))
+    expect_equal(isSymmetric(result), TRUE)
+    expect_equal(unname(diag(result)), rep(0, length(unique(sample_ids))))
+})
+
+
+


### PR DESCRIPTION
## Summary

This PR improves error handling and fixes R 4.5.2 compatibility issues in GloScope（Passed devtools::check() locally）:

1. **Enhanced error messages** for `prefit_density` parameter validation
2. **Fixed R 4.5.2 compatibility** in `.calc_dens()` function

## Changes

### 1. Improved Error Messages for `prefit_density` Parameter

**Problem:** Users often confuse `Mclust` and `densityMclust` objects from the `mclust` package. Previous error messages were uninformative:

```
Error: object is not of class 'densityMclust'
```

**Solution:** Added comprehensive validation with clear, actionable error messages:

```
Error: prefit_density$sample1 is a 'Mclust' object, but 'densityMclust' is required.
  Use mclust::densityMclust() instead of mclust::Mclust().
  Example: densityMclust(data, G = 12, modelNames = 'VVE', plot = FALSE)
  See ?gloscope for more details.
```

**Implementation (`R/gloscope.R`):**
- Validates each object in `prefit_density` list before processing
- Distinguishes between `Mclust` objects and other incorrect types
- Includes object names/indices in error messages for easier debugging
- Provides usage examples and documentation references

**Tests (`tests/testthat/test-prefit-density.R`):**
- 9 comprehensive test cases using `testthat` framework
- Tests error detection for `Mclust` objects, wrong types, named/unnamed lists
- Verifies correct functionality with proper `densityMclust` objects
- Uses small test datasets from `setup_data.R`

### 2. Fixed R 4.5.2 Compatibility in `.calc_dens()`

**Problem:** In R 4.5.2, `mclust::densityMclust()` fails when called via `do.call()` with matrices that lack column names, throwing:

```
Error in dimnames(x) <- dn: length of 'dimnames' [2] not equal to array extent
```

This affected two existing tests in `test-cell.R`:
- `"JS divergences are properly implemented"` (line 100)
- `"the sKL divergences are properly implemented"` (line 140)

**Root Cause:** When `mclust::densityMclust()` is invoked through `do.call()` in R 4.5.2, it attempts to set dimnames on the data matrix. If the matrix lacks column names, this operation fails. Direct calls (without `do.call()`) work fine, but our implementation uses `do.call()` to pass parameters dynamically.

**Solution:** Added column name normalization before parallel processing:

```r
# Ensure matrices have column names for R 4.5.2 compatibility
df_list <- lapply(df_list, function(mat){
    if (is.null(colnames(mat))) {
        colnames(mat) <- paste0("V", seq_len(ncol(mat)))
    }
    mat
})
```

**Why This Works:**
- Normalizes matrices once before the parallel loop (efficient)
- Only adds column names if missing (preserves existing names)
- Maintains backward compatibility with older R versions
- Fixes the failing tests without changing test logic

**Implementation (`R/calc_dens.R`):**
- Column name normalization happens before `BiocParallel::bplapply()`
- Prevents repeated matrix copying inside parallel workers
- Minimal performance impact (single pass over list)

## Testing

### Test Results
```
✓ All 9 new tests pass (test-prefit-density.R)
✓ All 89 existing tests pass (including previously failing tests)
✓ Total: [ FAIL 0 | WARN 0 | SKIP 0 | PASS 89 ]
```

### Previously Failing Tests (Now Fixed)
- `test-cell.R:100` - "JS divergences are properly implemented" ✅
- `test-cell.R:140` - "the sKL divergences are properly implemented" ✅


